### PR TITLE
AFNetworking 2 implementations

### DIFF
--- a/RunKeeper/RunKeeperFitnessActivity.h
+++ b/RunKeeper/RunKeeperFitnessActivity.h
@@ -7,7 +7,26 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RunKeeper.h"
+
+
+// All of the activity types supported by the RunKeeper API in a slick little enum
+typedef enum {
+    kRKRunning,
+    kRKCycling,
+    kRKMountainBiking,
+    kRKWalking,
+    kRKHiking,
+    kRKDownhillSkiing,
+    kRKXCountrySkiing,
+    kRKSnowboarding,
+    kRKSkating,
+    kRKSwimming,
+    kRKWheelchair,
+    kRKRowing,
+    kRKElliptical,
+    kRKOther
+} RunKeeperActivityType;
+
 
 /** FitnessActivity as returned by different fitnessActivities API end points 
     Depending on the API call and expected content type, only basic data, advanced or all fields are filled. */
@@ -81,5 +100,9 @@
 
 // The URL of the user’s public, human-readable page for this activity
 @property (nonatomic, strong) NSString* publicURI;
+
+
+/** Returns the proper string for API calls from the given acitivity type */
++ (NSString*)activityString:(RunKeeperActivityType)activity;
 
 @end

--- a/RunKeeper/RunKeeperFitnessActivity.m
+++ b/RunKeeper/RunKeeperFitnessActivity.m
@@ -15,12 +15,34 @@
 {
     return [NSString stringWithFormat:@"Date: %@, type: %@, distance: %.2f, duration: %.2f, calories: %@, cal/h: %.0f, uri: %@",
             _startTime,
-            [RunKeeper activityString:_activityType],
+            [RunKeeperFitnessActivity activityString:_activityType],
             _totalDistanceInMeters.doubleValue / 1000.0,
             _durationInSeconds.doubleValue / 60.0,
             _totalCalories,
             _totalCalories.doubleValue / (_durationInSeconds.doubleValue / 60.0) * 60.0,
             _uri];
+}
+
+
++ (NSString*)activityString:(RunKeeperActivityType)activity
+{
+    switch (activity) {
+        case kRKRunning:        return @"Running";
+        case kRKCycling:        return @"Cycling";
+        case kRKMountainBiking: return @"Mountain Biking";
+        case kRKWalking:        return @"Walking";
+        case kRKHiking:         return @"Hiking";
+        case kRKDownhillSkiing: return @"Downhill Skiing";
+        case kRKXCountrySkiing: return @"Cross Country Skiing";
+        case kRKSnowboarding:   return @"Snowboarding";
+        case kRKSkating:        return @"Skating";
+        case kRKSwimming:       return @"Swimming";
+        case kRKWheelchair:     return @"Wheelchair";
+        case kRKRowing:         return @"Rowing";
+        case kRKElliptical:     return @"Elliptical";
+        case kRKOther:          return @"Other";
+    }
+    return @"Running";
 }
 
 @end


### PR DESCRIPTION
This has been updated to use AFNetworking 2, instead of AFNetworking 1.x used in the last commit to master. 

Mainly, the use of AFHTTPClient has been replaced by AFHTTPRequestOperationManager. 